### PR TITLE
Add multi-head self-attention

### DIFF
--- a/MathNetClasses/TrainingFramework.cs
+++ b/MathNetClasses/TrainingFramework.cs
@@ -54,6 +54,7 @@ public static class TrainingFramework
         int vocabSize = 2500,
         int inputSize = 10,
         int embeddingSize = 100,
+        int numHeads = 2,
         float noiseVal = 0.1f,
         float percentToChange = 1f)
     {
@@ -63,6 +64,7 @@ public static class TrainingFramework
         model.Create01_CreateBigram("./SampleStr.txt");
         model.Create02_CreateEmbedding(embeddingSize);
         model.Create03_CreatePositionalEncoding(inputSize);
+        model.ModelDetails.NumHeads = numHeads;
         model.Create04_CreateSelfAttention();
         model.Create05_CreateFeedForward();
         model.Create04b_CreateSelfAttention2();

--- a/MathNetClasses/TransformerModel.cs
+++ b/MathNetClasses/TransformerModel.cs
@@ -72,6 +72,7 @@ public struct TransformerModelDetails
     public int   EmbeddingDim;
     public int   FFHiddenDim;
     public int   InputLen;
+    public int   NumHeads;
     public float NoiseVal;
     public float PercentChange;
     public int   NumIterations;
@@ -82,17 +83,19 @@ public struct TransformerModelDetails
         EmbeddingDim = 0;
         FFHiddenDim = 0;
         InputLen = 0;
+        NumHeads = 1;
         NoiseVal = 0f;
         PercentChange = 0f;
         NumIterations = 0;
     }
 
-    public TransformerModelDetails(int vocabSize, int embeddingDim, int ffHiddenDim, int inputLen, float noiseVal, float percentChange)
+    public TransformerModelDetails(int vocabSize, int embeddingDim, int ffHiddenDim, int inputLen, int numHeads, float noiseVal, float percentChange)
     {
         VocabSize     = vocabSize;
         EmbeddingDim  = embeddingDim;
         FFHiddenDim   = ffHiddenDim;
         InputLen      = inputLen;
+        NumHeads      = numHeads;
         NoiseVal      = noiseVal;
         PercentChange = percentChange;
         NumIterations = 0;
@@ -107,6 +110,7 @@ public struct TransformerModelDetails
             writer.WriteLine(EmbeddingDim);
             writer.WriteLine(FFHiddenDim);
             writer.WriteLine(InputLen);
+            writer.WriteLine(NumHeads);
             writer.WriteLine(NoiseVal.ToString("F4"));
             writer.WriteLine(PercentChange.ToString("F4"));
             writer.WriteLine(NumIterations);
@@ -123,6 +127,7 @@ public struct TransformerModelDetails
             newDetails.EmbeddingDim = int.Parse(reader.ReadLine());
             newDetails.FFHiddenDim = int.Parse(reader.ReadLine());
             newDetails.InputLen = int.Parse(reader.ReadLine());
+            newDetails.NumHeads = int.Parse(reader.ReadLine());
             newDetails.NoiseVal = float.Parse(reader.ReadLine());
             newDetails.PercentChange = float.Parse(reader.ReadLine());
             newDetails.NumIterations = int.Parse(reader.ReadLine());
@@ -273,7 +278,7 @@ public class TransformerModel
         if (Embedding == null)
             throw new Exception("Embedding must be created before creating the self-attention layer.");
 
-        SelfAtt = new SelfAttention(ModelDetails.InputLen, ModelDetails.EmbeddingDim);
+        SelfAtt = new SelfAttention(ModelDetails.InputLen, ModelDetails.EmbeddingDim, ModelDetails.NumHeads);
     }
 
     public void Create05_CreateFeedForward()
@@ -290,7 +295,7 @@ public class TransformerModel
         if (FeedForward == null)
             throw new Exception("Feed-forward must be created before creating the second self-attention layer.");
 
-        SelfAtt2 = new SelfAttention(ModelDetails.InputLen, ModelDetails.EmbeddingDim);
+        SelfAtt2 = new SelfAttention(ModelDetails.InputLen, ModelDetails.EmbeddingDim, ModelDetails.NumHeads);
     }
 
     public void Create05b_CreateFeedForward2()

--- a/Program.cs
+++ b/Program.cs
@@ -55,7 +55,8 @@ namespace MathNetDemo
                 modeldirname,
                 vocabSize: 2500,
                 inputSize: 10,
-                embeddingSize: 50);
+                embeddingSize: 50,
+                numHeads: 2);
         }
 
         public static void DemoModel100K_Train()
@@ -142,7 +143,8 @@ namespace MathNetDemo
                 modeldirname,
                 vocabSize: 3500,
                 inputSize: 20,
-                embeddingSize: 60);
+                embeddingSize: 60,
+                numHeads: 2);
         }
 
         public static void DemoModel500K_Train()


### PR DESCRIPTION
## Summary
- implement multi-head self-attention
- store number of heads in model details
- allow creating models with a configurable number of attention heads

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686710d5f7f8832c99b8b273431d3535